### PR TITLE
Implement contig dma

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Sample code to call `ioctl`:
         char miscdev_path[PATH_MAX];
         char miscdev_name[CRONO_DEV_NAME_MAX_SIZE];
         struct crono_dev_DBDF dbdf = {0, 0, 2, 0};
-        CRONO_BUFFER_INFO buff_info;
+        CRONO_SG_BUFFER_INFO buff_info;
 
         // Get the miscdev file path, e.g. `/dev/crono_06_0002000`
         CRONO_CONSTRUCT_MISCDEV_NAME(miscdev_name, 0x06, dbdf);
@@ -537,7 +537,7 @@ Simple skeleton steps are like:
 3. The process `12345` opens `/dev/crono_06_0003000` by calling `open()`, returning file descriptor `fdB`. 
 4. The process `12345` calls `ioctl()` using `fdB` to lock `BufferC` (allocated previously in userspace `12345`).
 5. In the kernel module, `ioctl()` receives a `struct file*` of value `filpD` (in kernel space) that is related to `fdB` (in userspace).  
-6. The kernel module then locks the buffer `BufferC` and assign it to process `12345` (`CRONO_BUFFER_INFO_WRAPPER`.`app_pid`).
+6. The kernel module then locks the buffer `BufferC` and assign it to process `12345` (`CRONO_SG_BUFFER_INFO_WRAPPER`.`app_pid`).
 
 Although a cronologic device can have one and only one ring buffer, but the chart was provided as a general example.
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,8 @@ Sample code to call `ioctl`:
 }
 ```
 
+* This example is provided for Scatter/Gather memory allocation, however, the driver provides functionality to lock contiguous memory directly as well using `CRONO_CONTIG_BUFFER_INFO` and `IOCTL_CRONO_LOCK_CONTIG_BUFFER`.
+
 ## Miscellaneous Device Driver Naming Convension
 The misc driver name is consutructed following the macro [CRONO_CONSTRUCT_MISCDEV_NAME](https://github.com/cronologic-de/cronologic_linux_kernel/blob/main/include/crono_linux_kernel.h#L80)
 ```C

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="crono_pci_drvmod"
-PACKAGE_VERSION="1.0.3"
+PACKAGE_VERSION="1.1.0"
 BUILT_MODULE_NAME[0]="crono_pci_drvmod" # No explicit `.ko`
 BUILT_MODULE_LOCATION[0]="src/release_64/" # Relative to dkms.conf folder 
 DEST_MODULE_LOCATION[0]="/extra" # Ignored

--- a/include/crono_linux_kernel.h
+++ b/include/crono_linux_kernel.h
@@ -21,6 +21,10 @@
 
 typedef uint64_t DMA_ADDR;
 
+/**
+ * @brief
+ * Buffer info communicated with user space for scatter/gather memory
+ */
 typedef struct {
         // Buffer Information
         void *addr;  // Physical address of buffer, allocated by userspace.
@@ -38,6 +42,18 @@ typedef struct {
         // Kernel Information
         int id; // Internal kernel ID of the buffer
 } CRONO_BUFFER_INFO;
+
+/**
+ * @brief
+ * Buffer info communicated with user space for contiguous memory
+ */
+typedef struct {
+        void *addr;  // Physical address of buffer, in userspace
+        size_t size; // Size of the buffer in bytes.
+
+        // Kernel Information
+        int id;            // Internal kernel ID of the buffer
+} CRONO_KERNEL_DMA_CONTIG;
 
 /**
  * CRONO PCI Driver Name passed in pci_driver structure, and is found under
@@ -96,5 +112,15 @@ typedef struct {
  * Command value passed to miscdev ioctl() to cleanup setup
  */
 #define IOCTL_CRONO_CLEANUP_SETUP _IOWR('c', 2, CRONO_KERNEL_CMDS_INFO *)
+/**
+ * Command value passed to miscdev ioctl() to lock a contiguour memory buffer.
+ * 'c' is for `cronologic`.
+ */
+#define IOCTL_CRONO_LOCK_CONTIG_BUFFER _IOWR('c', 3, CRONO_BUFFER_INFO *)
+/**
+ * Command value passed to miscdev ioctl() to unlock a contiguous memory buffer
+ * 'c' is for `cronologic`. Passing buffer wrapper ID in kernel module.
+ */
+#define IOCTL_CRONO_UNLOCK_CONTIG_BUFFER _IOWR('c', 4, int *)
 
 #endif // #ifndef _CRONO_LINUX_KERNEL_H_

--- a/include/crono_linux_kernel.h
+++ b/include/crono_linux_kernel.h
@@ -41,7 +41,7 @@ typedef struct {
 
         // Kernel Information
         int id; // Internal kernel ID of the buffer
-} CRONO_BUFFER_INFO;
+} CRONO_SG_BUFFER_INFO;
 
 /**
  * @brief
@@ -52,8 +52,8 @@ typedef struct {
         size_t size; // Size of the buffer in bytes.
 
         // Kernel Information
-        int id;            // Internal kernel ID of the buffer
-} CRONO_KERNEL_DMA_CONTIG;
+        int id; // Internal kernel ID of the buffer
+} CRONO_CONTIG_BUFFER_INFO;
 
 /**
  * CRONO PCI Driver Name passed in pci_driver structure, and is found under
@@ -102,7 +102,7 @@ typedef struct {
  * Command value passed to miscdev ioctl() to lock a memory buffer.
  * 'c' is for `cronologic`.
  */
-#define IOCTL_CRONO_LOCK_BUFFER _IOWR('c', 0, CRONO_BUFFER_INFO *)
+#define IOCTL_CRONO_LOCK_BUFFER _IOWR('c', 0, CRONO_SG_BUFFER_INFO *)
 /**
  * Command value passed to miscdev ioctl() to unlock a memory buffer
  * 'c' is for `cronologic`. Passing buffer wrapper ID in kernel module.
@@ -116,7 +116,7 @@ typedef struct {
  * Command value passed to miscdev ioctl() to lock a contiguour memory buffer.
  * 'c' is for `cronologic`.
  */
-#define IOCTL_CRONO_LOCK_CONTIG_BUFFER _IOWR('c', 3, CRONO_BUFFER_INFO *)
+#define IOCTL_CRONO_LOCK_CONTIG_BUFFER _IOWR('c', 3, CRONO_CONTIG_BUFFER_INFO *)
 /**
  * Command value passed to miscdev ioctl() to unlock a contiguous memory buffer
  * 'c' is for `cronologic`. Passing buffer wrapper ID in kernel module.

--- a/include/crono_linux_kernel.h
+++ b/include/crono_linux_kernel.h
@@ -39,7 +39,7 @@ typedef struct {
                          // with kernel versions earlier than 5.6
         uint32_t pages_count; // Count pages in `pages`
 
-        // Kernel Information
+        // Kernel internal information
         int id; // Internal kernel ID of the buffer
 } CRONO_SG_BUFFER_INFO;
 
@@ -48,10 +48,12 @@ typedef struct {
  * Buffer info communicated with user space for contiguous memory
  */
 typedef struct {
-        void *addr;  // Physical address of buffer, in userspace
         size_t size; // Size of the buffer in bytes.
 
-        // Kernel Information
+        void *pUserAddr; // Processor's (kernel) virtual address space
+        uint64_t addr; // DMA (dma_addr_t Pysical) address base of the region, dma_handle
+
+        // Kernel internal information
         int id; // Internal kernel ID of the buffer
 } CRONO_CONTIG_BUFFER_INFO;
 

--- a/include/crono_linux_kernel.h
+++ b/include/crono_linux_kernel.h
@@ -50,8 +50,9 @@ typedef struct {
 typedef struct {
         size_t size; // Size of the buffer in bytes.
 
-        void *pUserAddr; // Processor's (kernel) virtual address space
-        uint64_t addr; // DMA (dma_addr_t Pysical) address base of the region, dma_handle
+        void *addr; // Processor's (kernel) virtual address space
+        void *pUserAddr;
+        uint64_t dma_handle;
 
         // Kernel internal information
         int id; // Internal kernel ID of the buffer

--- a/src/crono_kernel_module.c
+++ b/src/crono_kernel_module.c
@@ -1614,8 +1614,13 @@ static int crono_mmap_contig(struct file *file, struct vm_area_struct *vma) {
 
         PR_DEBUG_BW_INFO("remap_pfn_range:", found_buff_wrapper);
         pr_debug("found_buff_wrapper->dma_handle %lld, size %ld \n", found_buff_wrapper->dma_handle, found_buff_wrapper->buff_info.size);
+	    uint32_t *data = (uint32_t*) found_buff_wrapper->buff_info.addr;
+	    data[0] = 0x1234567;
+	    data[1] = 0x89ABDEF0;
+    	void *virttophys = virt_to_phys(found_buff_wrapper->buff_info.addr);
+        pr_debug("found_buff_wrapper->dma_handle %lld, virt_to_phys %lld \n", found_buff_wrapper->dma_handle, virttophys);
         ret = remap_pfn_range(
-            vma, vma->vm_start, found_buff_wrapper->dma_handle >> PAGE_SHIFT,
+			      vma, vma->vm_start, ((uint64_t) virttophys) >> PAGE_SHIFT,
             found_buff_wrapper->buff_info.size, vma->vm_page_prot);
         pr_debug("Mapping Buffer Wrapper <%d> returned <%d>", bw_id, ret);
         return ret;

--- a/src/crono_kernel_module.c
+++ b/src/crono_kernel_module.c
@@ -1598,14 +1598,15 @@ static int _crono_miscdev_ioctl_unlock_contig_buffer(struct file *filp,
 }
 
 static int crono_mmap_contig(struct file *file, struct vm_area_struct *vma) {
-    // $$$ consider calling mmap with NULL last argument `crono_get_BAR0_mem_addr` or debug it
-        // `mmap` `offset` argument should be aligned on a page boundary, so the
-        // buffer id is sent to `mmap` multiplied by PAGE_SIZE.
-        int bw_id = vma->vm_pgoff / PAGE_SIZE;
+        // `mmap` `offset` (last) argument should be aligned on a page boundary, so the
+        // buffer id is sent to `mmap` multiplied by PAGE_SIZE, however, it's recieved
+        // here divided by PATE_SIZE already 
+        int bw_id = vma->vm_pgoff; 
         int ret = CRONO_SUCCESS;
         CRONO_CONTIG_BUFFER_INFO_WRAPPER *found_buff_wrapper = NULL;
 
         pr_debug("Mapping Buffer Wrapper <%d>, offset: <%lu>", bw_id, vma->vm_pgoff);
+        
         if (CRONO_SUCCESS != get_bw(bw_id, &found_buff_wrapper)) {
                 pr_err("Buffer wrapper <%d> is not found", bw_id);
                 return -EINVAL;

--- a/src/crono_kernel_module.c
+++ b/src/crono_kernel_module.c
@@ -1535,7 +1535,7 @@ static int _crono_miscdev_ioctl_lock_contig_buffer(struct file *filp,
 
         // Copy back all data to userspace memory, including address
         // of the allocated memory
-        if (copy_to_user((void __user *)arg, &(buff_wrapper->buff_info),
+        if (copy_to_user((void __user *)arg, &(bw->buff_info),
                          sizeof(CRONO_CONTIG_BUFFER_INFO))) {
                 pr_err("Error copying buffer information back to user space");
                 ret = -EFAULT;

--- a/src/crono_kernel_module.c
+++ b/src/crono_kernel_module.c
@@ -1441,7 +1441,13 @@ static int _crono_init_contig_buff_wrapper(
         // Get device pointer in internal structure
         ret = _crono_get_dev_from_filp(filp, &(buff_wrapper->ntrn.devp));
         if (ret != CRONO_SUCCESS) {
-                goto func_err;
+                return -EIO;
+        }
+
+        ret = dma_set_mask_and_coherent(&buff_wrapper->ntrn.devp->dev, DMA_BIT_MASK(64));
+        if (ret) {
+                pr_err("Error seting mask: %d", ret);
+                return -EIO;
         }
 
         // Allocate contiguous memory in kernel space
@@ -1451,7 +1457,7 @@ static int _crono_init_contig_buff_wrapper(
         if (buff_wrapper->kernel_buff == NULL) {
                 // Just null, no global error setting, check `dmsg` if you
                 // need any details
-                ret = -ENOMEM; // Or appropriate error
+                return -ENOMEM; // Or appropriate error
         }
 
         // Since the buffer is kernel-space address returned by
@@ -1471,10 +1477,6 @@ static int _crono_init_contig_buff_wrapper(
         sg_buff_wrappers_new_id++;
         _crono_debug_list_wrappers();
 
-        return ret;
-
-func_err:
-        crono_kvfree(buff_wrapper);
         return ret;
 }
 

--- a/src/crono_kernel_module.c
+++ b/src/crono_kernel_module.c
@@ -1614,7 +1614,6 @@ static int crono_mmap_contig(struct file *file, struct vm_area_struct *vma) {
 
         PR_DEBUG_BW_INFO("remap_pfn_range:", found_buff_wrapper);
         pr_debug("found_buff_wrapper->dma_handle %lld, size %ld \n", found_buff_wrapper->dma_handle, found_buff_wrapper->buff_info.size);
-        return ret; // $$ testing
         ret = remap_pfn_range(
             vma, vma->vm_start, found_buff_wrapper->dma_handle >> PAGE_SHIFT,
             found_buff_wrapper->buff_info.size, vma->vm_page_prot);

--- a/src/crono_kernel_module.h
+++ b/src/crono_kernel_module.h
@@ -3,6 +3,7 @@
 // _____________________________________________________________________________
 
 #include <asm/unistd.h>
+#include <linux/dma-mapping.h>
 #include <linux/fcntl.h>
 #include <linux/kernel.h>
 #include <linux/miscdevice.h>
@@ -11,7 +12,6 @@
 #include <linux/pci.h>
 #include <linux/sched.h>
 #include <linux/syscalls.h>
-#include <linux/dma-mapping.h>
 
 #ifdef OLD_KERNEL_FOR_PIN
 #include <linux/uaccess.h>
@@ -119,12 +119,12 @@ static int crono_driver_probe(struct pci_dev *dev,
 typedef uint64_t DMA_ADDR;
 
 // Buffer Wrapper Type
-#define BWT_SG          1
-#define BWT_CONTIG      2
+#define BWT_SG 1
+#define BWT_CONTIG 2
 typedef struct {
         int bwt;
         struct list_head list; // Linux list node info
-        struct pci_dev *devp;     // Owner device
+        struct pci_dev *devp;  // Owner device
         int app_pid; // Process ID of the userspace application that owns the
                      // buffer
 } CRONO_BUFFER_INFO_WRAPPER_INTERNAL;
@@ -136,7 +136,7 @@ typedef struct {
 typedef struct {
         CRONO_BUFFER_INFO_WRAPPER_INTERNAL ntrn;
 
-        CRONO_BUFFER_INFO buff_info;
+        CRONO_SG_BUFFER_INFO buff_info;
 
         void **kernel_pages; // Array of pointers to kernel page `page`. Needed
                              // to be cached for `unpin_user_pages`.
@@ -147,16 +147,16 @@ typedef struct {
         size_t pinned_size;        // Actual size pinned of the buffer in bytes.
         uint32_t pinned_pages_nr; // Number of actual pages pinned, needed to be
                                   // known if pin failed.
-} CRONO_BUFFER_INFO_WRAPPER;
+} CRONO_SG_BUFFER_INFO_WRAPPER;
 
 typedef struct {
         CRONO_BUFFER_INFO_WRAPPER_INTERNAL ntrn;
 
-        CRONO_KERNEL_DMA_CONTIG buff_info;
+        CRONO_CONTIG_BUFFER_INFO buff_info;
 
-        void* kernel_buff;     
+        void *kernel_buff;
         dma_addr_t dma_handle;
-} CRONO_CONTIG_BUFFER_INFO_WRAPPER; 
+} CRONO_CONTIG_BUFFER_INFO_WRAPPER;
 
 /**
  * Function displays information about the list of wrappers found in list

--- a/src/crono_kernel_module.h
+++ b/src/crono_kernel_module.h
@@ -153,9 +153,6 @@ typedef struct {
         CRONO_BUFFER_INFO_WRAPPER_INTERNAL ntrn;
 
         CRONO_CONTIG_BUFFER_INFO buff_info;
-
-        void *kernel_buff;
-        dma_addr_t dma_handle;
 } CRONO_CONTIG_BUFFER_INFO_WRAPPER;
 
 /**

--- a/src/crono_kernel_module.h
+++ b/src/crono_kernel_module.h
@@ -135,9 +135,6 @@ typedef struct {
  */
 typedef struct {
         CRONO_BUFFER_INFO_WRAPPER_INTERNAL ntrn;
-
-        CRONO_SG_BUFFER_INFO buff_info;
-
         void **kernel_pages; // Array of pointers to kernel page `page`. Needed
                              // to be cached for `unpin_user_pages`.
         void *sgt; // Scatter/Gather Table that holds the pinned pages.
@@ -147,12 +144,17 @@ typedef struct {
         size_t pinned_size;        // Actual size pinned of the buffer in bytes.
         uint32_t pinned_pages_nr; // Number of actual pages pinned, needed to be
                                   // known if pin failed.
+
+        CRONO_SG_BUFFER_INFO buff_info;
+
 } CRONO_SG_BUFFER_INFO_WRAPPER;
 
 typedef struct {
         CRONO_BUFFER_INFO_WRAPPER_INTERNAL ntrn;
+        dma_addr_t dma_handle; 
 
         CRONO_CONTIG_BUFFER_INFO buff_info;
+
 } CRONO_CONTIG_BUFFER_INFO_WRAPPER;
 
 /**

--- a/src/crono_kernel_module.h
+++ b/src/crono_kernel_module.h
@@ -151,7 +151,7 @@ typedef struct {
 
 typedef struct {
         CRONO_BUFFER_INFO_WRAPPER_INTERNAL ntrn;
-        dma_addr_t dma_handle; 
+        dma_addr_t dma_handle;
 
         CRONO_CONTIG_BUFFER_INFO buff_info;
 

--- a/src/crono_miscdevice.h
+++ b/src/crono_miscdevice.h
@@ -47,8 +47,8 @@ static int crono_miscdev_release(struct inode *inode, struct file *file);
  * @param file[in]: is a valid miscdev file for the device.
  * @param cmd[in]: is a valid miscdev ioctl command defined in
  * 'crono_linux_kernel.h`.
- * @param arg[in/out]: is a pointer to valid `CRONO_BUFFER_INFO` object in user
- * space memory.
+ * @param arg[in/out]: is a pointer to valid `CRONO_SG_BUFFER_INFO` object in
+ * user space memory.
  *
  * @return `CRONO_SUCCESS` in case of no error, or `errno` in case of error.
  */
@@ -73,7 +73,7 @@ static int _crono_get_DBDF_from_dev(struct pci_dev *dev,
  * It locks the buffer, and `copy_to_user` is called for all memory.
  *
  * @param filp[in]: the file descriptor passed to ioctl.
- * @param arg[in/out]: is a valid `CRONO_BUFFER_INFO` object pointer in user
+ * @param arg[in/out]: is a valid `CRONO_SG_BUFFER_INFO` object pointer in user
  * space memory. The object should have all members set, except the `id`, which
  * will be sit inside this function upon successful return.
  *
@@ -130,13 +130,13 @@ static int _crono_miscdev_ioctl_unlock_contig_buffer(struct file *filp,
  *
  * @param filep[in]: A valid file descriptor of the device file.
  * @param buff_wrapper[in/out]: is a valid kernel pointer to the stucture
- * `CRONO_BUFFER_INFO`.
+ * `CRONO_SG_BUFFER_INFO`.
  *
  * @return `CRONO_SUCCESS` in case of no error, or `errno` in case of error.
  */
 static int
 _crono_miscdev_ioctl_generate_sg(struct file *filp,
-                                 CRONO_BUFFER_INFO_WRAPPER *buff_wrapper);
+                                 CRONO_SG_BUFFER_INFO_WRAPPER *buff_wrapper);
 
 /**
  * Internal function called by `_crono_miscdev_ioctl_lock_sg_buffer`.
@@ -175,11 +175,11 @@ _crono_miscdev_ioctl_generate_sg(struct file *filp,
  */
 static int
 _crono_miscdev_ioctl_pin_buffer(struct file *filp,
-                                CRONO_BUFFER_INFO_WRAPPER *buff_wrapper,
+                                CRONO_SG_BUFFER_INFO_WRAPPER *buff_wrapper,
                                 unsigned long nr_per_call);
 
 /**
- * For CRONO_BUFFER_INFO_WRAPPER:
+ * For CRONO_SG_BUFFER_INFO_WRAPPER:
  * Unpin, unmap Scatter/Gather list, free all memory allocated for
  * `buff_wrapper`, and remove it from the buffer information wrappers.
  * `buff_wrapper` should have been initialized using
@@ -191,7 +191,7 @@ _crono_miscdev_ioctl_pin_buffer(struct file *filp,
  * Caller should free `buff_wrapper`.
  *
  * @param buff_wrapper[in/out]
- * CRONO_BUFFER_INFO_WRAPPER or CRONO_CONTIG_BUFFER_INFO_WRAPPER, based
+ * CRONO_SG_BUFFER_INFO_WRAPPER or CRONO_CONTIG_BUFFER_INFO_WRAPPER, based
  * on .ntrn.bwt
  *
  * @return `CRONO_SUCCESS` in case of success, or errno in case of error.
@@ -206,7 +206,7 @@ static int _crono_release_buff_wrapper(void *buff_wrapper);
  * controller of the device is disabled even if the user application crashes
  * unexpectedly
  *
- * @param arg[in]: is a pointer to valid `CRONO_BUFFER_INFO` object in user
+ * @param arg[in]: is a pointer to valid `CRONO_SG_BUFFER_INFO` object in user
  * space memory.
  */
 static int _crono_miscdev_ioctl_cleanup_setup(struct file *filp,
@@ -251,18 +251,18 @@ static int _crono_get_crono_dev_from_filp(struct file *filp,
                                           struct crono_miscdev **crono_devpp);
 
 /**
- * @brief Construct a new 'CRONO_BUFFER_INFO_WRAPPER' object from `arg`.
+ * @brief Construct a new 'CRONO_SG_BUFFER_INFO_WRAPPER' object from `arg`.
  * Adds the wrapper to the buffer information wrappers list.
  * Call `_crono_release_buff_wrapper` when done working with the wrapper.
  *
  * @param filp[in]: the file descriptor passed to ioctl.
- * @param arg[in]: is a pointer to valid `CRONO_BUFFER_INFO` object in user
+ * @param arg[in]: is a pointer to valid `CRONO_SG_BUFFER_INFO` object in user
  * space memory.
  * @param pp_buff_wrapper[out]
  */
 static int
 _crono_init_sg_buff_wrapper(struct file *filp, unsigned long arg,
-                            CRONO_BUFFER_INFO_WRAPPER **pp_buff_wrapper);
+                            CRONO_SG_BUFFER_INFO_WRAPPER **pp_buff_wrapper);
 
 /**
  * If `val` is NULL, then it logs error message `err_msg` and returns `errno`.

--- a/src/crono_miscdevice.h
+++ b/src/crono_miscdevice.h
@@ -87,7 +87,7 @@ static int _crono_miscdev_ioctl_lock_sg_buffer(struct file *filp,
  * @brief
  *
  * @param filp
- * @param arg is a valid `CRONO_KERNEL_DMA_CONTIG`
+ * @param arg is an address of a valid `CRONO_CONTIG_BUFFER_INFO`
  * @return int
  */
 static int _crono_miscdev_ioctl_lock_contig_buffer(struct file *filp,

--- a/src/crono_miscdevice.h
+++ b/src/crono_miscdevice.h
@@ -82,9 +82,9 @@ static int _crono_get_DBDF_from_dev(struct pci_dev *dev,
 static int _crono_miscdev_ioctl_lock_sg_buffer(struct file *filp,
                                                unsigned long arg);
 
-// $$ documentation
 /**
  * @brief
+ * Lock contiguous buffer for 32bit using dma_alloc_coherent
  *
  * @param filp
  * @param arg is an address of a valid `CRONO_CONTIG_BUFFER_INFO`
@@ -107,7 +107,13 @@ static int _crono_miscdev_ioctl_lock_contig_buffer(struct file *filp,
 static int _crono_miscdev_ioctl_unlock_sg_buffer(struct file *filp,
                                                  unsigned long arg);
 
-// $$ documentation, pass id
+/**
+ * @brief
+ * Lock contiguous buffer for 32bit using dma_alloc_coherent
+ *
+ * @param filp
+ * @param arg is the wrapper id (CRONO_CONTIG_BUFFER_INFO.id) of the buffer.
+ */
 static int _crono_miscdev_ioctl_unlock_contig_buffer(struct file *filp,
                                                      unsigned long arg);
 

--- a/tools/conanfile.py
+++ b/tools/conanfile.py
@@ -12,7 +12,7 @@ class CronoLinuxKerneModuleConan(ConanFile):
     # __________________________________________________________________________
     # Values to be reviewed with every new version
     #
-    version = "1.0.2"
+    version = "1.1.0"
 
     # __________________________________________________________________________
     # Member variables


### PR DESCRIPTION
**`v1.1.0`: Support of allocating contiguous memory by the driver**
- Memory is allocated by the kernel module (and not by the user space like SG model), using `dma_alloc_coherent`.
- `mmap` is provided to map memory:
   - Uses `virt_to_phys` to return the corresponding physical address.
   - Calls `remap_pfn_range` of the physical memory.
- Set mask to `DMA_BIT_MASK(32)` supported by cards.
- Added `IOCTL_CRONO_LOCK_CONTIG_BUFFER` and `IOCTL_CRONO_UNLOCK_CONTIG_BUFFER`.
- Renamed `CRONO_BUFFER_INFO` to be `CRONO_SG_BUFFER_INFO`.